### PR TITLE
Cabalify Alex and Happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,7 @@
-hython: src/Lexer.hs src/Parser.hs src/Language.hs src/Interpreter.hs hython.cabal
+hython: src/Lexer.x src/Parser.y src/Language.hs src/Interpreter.hs hython.cabal
 	@cabal build
 	-@./.cabal-sandbox/bin/hlint src/Language.hs src/Interpreter.hs
 	@ln -sf dist/build/hython/hython .
-
-src/Lexer.hs: src/Lexer.x
-	./.cabal-sandbox/bin/alex -g -o src/Lexer.hs src/Lexer.x
-
-src/Parser.hs: src/Parser.y
-	./.cabal-sandbox/bin/happy -a -g -c -o src/Parser.hs src/Parser.y
 
 .PHONY: test
 test: hython

--- a/hython.cabal
+++ b/hython.cabal
@@ -6,6 +6,7 @@ cabal-version:    >= 1.2
 executable        hython
   build-depends:  base, containers, mtl, array, utf8-string, regex-base, regex-compat, transformers
   build-tools:    alex, happy
+  other-modules:  Lexer, Parser
   hs-source-dirs: src
   main-is:        Interpreter.hs
   ghc-options:    -Wall -fno-warn-missing-signatures -debug


### PR DESCRIPTION
There's no need to invoke alex and happy from a Makefile. In fact,
invoking them via the Cabal file makes it easier for people to build
Hython out-of-the-box.

Signed-off-by: Pekka Enberg penberg@iki.fi
