### PR TITLE
Let Makefile create hard link to executable (instead of symbolic link)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SOURCES = $(shell find src -type f -name '*.hs' -o -name '*.y')
 hython: hython.cabal stack.yaml $(SOURCES)
 	@stack build -j4
 	@stack exec hlint -- src
-	@ln -sf $(shell stack path --dist-dir)/build/hython/hython .
+	@ln -f $(shell stack path --dist-dir)/build/hython/hython .
 
 .PHONY: test
 test: hython


### PR DESCRIPTION
After checking out and building the project as stated in the Readme, running ```make test``` or ```./hython``` failed.

The reason is that the executable is located somewhere like ```.stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/hython/hython``` and thus tries to find the builtins there as well (the code uses ```splitExecutablePath``` to get the module paths).

```
$ git clone https://github.com/mattgreen/hython.git
$ cd hython
$ make
$ ./hython test/fib.py 
hython: /home/ubuntu/mheinzel/tmp/hython/.stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/hython/lib/builtins: canonicalizePath: does not exist (No such file or directory)
```

This can be solved by using a hard link or copying the file (whatever you think is the best solution).
I would personally not have a problem with you not merging this, but maybe it saves some people from having to figure out what is going wrong.


PS: I am probably going to work on this project a bit, e.g. implementing generators/yield. Are you interested in receiving pull requests for these things as well?

Matthias