### PR TITLE
Improve error handling

### DIFF
--- a/hython.cabal
+++ b/hython.cabal
@@ -29,6 +29,7 @@ executable        hython
   build-tools:    happy
   other-modules:  Language.Python.Lexer,
                   Language.Python.Parser,
+                  Language.Python,
                   REPL,
                   Hython.Interpreter,
                   Hython.Statement,
@@ -36,6 +37,8 @@ executable        hython
                   Hython.Types,
                   Hython.Expression,
                   Hython.Builtins,
+                  Hython.Name,
+                  Hython.ExceptionHandling
                   Hython.ControlFlow,
                   Hython.Call,
                   Hython.Ref,

--- a/src/Language/Python/Parser.y
+++ b/src/Language/Python/Parser.y
@@ -693,7 +693,7 @@ parse :: Text -> Either String [Statement]
 parse code = do
     case L.lex code of
         Right tokens    -> parseTokens tokens
-        Left err        -> Left $ show err
+        Left err        -> Left $ "SyntaxError: " ++ show err
 
 parseRepl :: Text -> Either String [Statement]
 parseRepl code = do
@@ -701,6 +701,6 @@ parseRepl code = do
         Right tokens    -> parseLine tokens
         Left err        -> Left $ show err
 
-parseError t = Left $ "Parse error: " ++ show t
+parseError t = Left $ "SyntaxError: at " ++ show t
 
 }

--- a/src/Language/Python/Parser.y
+++ b/src/Language/Python/Parser.y
@@ -13,6 +13,7 @@ import qualified Language.Python.Lexer as L
 
 %tokentype  {L.Token}
 %error      { parseError }
+%monad { Either String } { (>>=) } { return }
 
 %name parseTokens file_input
 %name parseLine single_input
@@ -691,15 +692,15 @@ mkName s = Name . T.pack $ s
 parse :: Text -> Either String [Statement]
 parse code = do
     case L.lex code of
-        Right tokens    -> Right $ parseTokens tokens
+        Right tokens    -> parseTokens tokens
         Left err        -> Left $ show err
 
 parseRepl :: Text -> Either String [Statement]
 parseRepl code = do
     case L.lex code of
-        Right tokens    -> Right $ parseLine tokens
+        Right tokens    -> parseLine tokens
         Left err        -> Left $ show err
 
-parseError :: [L.Token] -> a
-parseError t = error $ "Parse error: " ++ show t
+parseError t = Left $ "Parse error: " ++ show t
+
 }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,6 +10,7 @@ import Data.Text.IO (readFile)
 
 import System.Environment
 import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
 import System.IO.Error
 
 import Hython.Interpreter (defaultInterpreterState, runInterpreter)
@@ -22,7 +23,8 @@ main = do
         []          -> runREPL
         [filename]  -> runScript filename
         _           -> do
-            putStrLn "Usage: hython <filename>"
+            progName <- getProgName
+            hPutStrLn stderr $ "Usage: " ++ progName ++ " [filename]"
             exitFailure
 
 runScript :: FilePath -> IO ()
@@ -33,7 +35,7 @@ runScript path = do
     (result, _) <- runInterpreter state code
     case result of
         Left msg    -> do
-            putStrLn msg
+            hPutStrLn stderr msg
             exitFailure
         Right _     -> return ()
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,7 +11,6 @@ import Data.Text.IO (readFile)
 import System.Environment
 import System.Exit (exitFailure)
 import System.IO.Error
-import Text.Printf
 
 import Hython.Interpreter (defaultInterpreterState, runInterpreter)
 import REPL (runREPL)
@@ -39,6 +38,5 @@ runScript path = do
   where
     errorHandler :: String -> IOError -> IO Text
     errorHandler _ err = do
-        putStrLn $ printf "Unable to open '%s': file %s" path (ioeGetErrorString err)
-        _ <- exitFailure
-        return ""
+        putStrLn $ "Unable to open '" ++ path ++ "': " ++ ioeGetErrorString err
+        exitFailure

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -32,7 +32,9 @@ runScript path = do
 
     (result, _) <- runInterpreter state code
     case result of
-        Left msg    -> putStrLn msg
+        Left msg    -> do
+            putStrLn msg
+            exitFailure
         Right _     -> return ()
 
   where


### PR DESCRIPTION
Previously, in some places ```error``` and ```exitFailure``` were used to handle errors, so the whole program terminated.
Now the parsing uses ```Either``` (which was much simpler than I thought) and in case of an uncaught exception, the continuation is aborted.

To obtain the terminating continuation, we have to use callCC inside the ```Interpreter``` monad, which means it can no be set in the initial state. I'm not really happy with that solution, but can't think of anything more elegant at the moment.

The nice thing is, the REPL now doesn't close itself when encountering a parsing error or uncaught exception. It just ignores the current line, like the regular Python REPL.

This is the first time I'm working with monad transformer stacks, so it takes some time to grasp all the details, but it's fun and I already learned a lot. I want to do 1 or 2 more small fixes, then I am going to  tackle generators.

Matthias