### PR TITLE
Only allow to raise and catch exceptions deriving from BaseException

### DIFF
--- a/src/Hython/ExceptionHandling.hs
+++ b/src/Hython/ExceptionHandling.hs
@@ -3,29 +3,44 @@ where
 
 import Control.Monad.Cont.Class (MonadCont)
 import Data.Text (Text)
+import qualified Data.Text as T
 
 import Hython.Call (call)
+import Hython.Class (isSubClass)
 import Hython.ControlFlow (getExceptionHandler, setCurrentException)
 import Hython.Environment (MonadEnv, lookupName)
-import Hython.Types (MonadInterpreter, newString, Object)
+import Hython.Types hiding (raise)
 import qualified Hython.Types as Types
 
-raise :: MonadInterpreter m => Object -> m ()
-raise exception = do
-    handler <- getExceptionHandler
 
-    setCurrentException exception
-    handler exception
+raiseOr :: (MonadEnv Object m, MonadInterpreter m) => m () -> Object -> m ()
+raiseOr raiseError exc@(Object objectInfo) = do
+    mBaseClass <- lookupName (T.pack "BaseException")
+    case mBaseClass of
+        Just (Class baseClassInfo) ->
+            if isSubClass (objectClass objectInfo) baseClassInfo
+                then do
+                    handler <- getExceptionHandler
+                    setCurrentException exc
+                    handler exc
+                else raiseError
+        _ -> Types.raise "SystemError" "could not find BaseException class"
+raiseOr raiseError _ = raiseError
+
+raiseExternal :: (MonadEnv Object m, MonadInterpreter m) => Object -> m ()
+raiseExternal =
+    raiseOr $ Types.raise "TypeError" "exceptions must derive from BaseException"
 
 raiseInternal :: (MonadCont m, MonadEnv Object m, MonadInterpreter m) => Text -> Text -> m ()
 raiseInternal clsName description = do
     mcls <- lookupName clsName
     case mcls of
-        Just obj    -> do
+        Just cls@(Types.Class _) -> do
             descriptionStr  <- newString description
-            exception       <- call obj [descriptionStr] []
-            raise exception
-        _           -> Types.raise "TypeError" "exceptions must derive from BaseException"
-
-
+            exception       <- call cls [descriptionStr] []
+            raiseOr raiseError exception
+        _ -> raiseError
+  where
+    raiseError = Types.raise "SystemError" ("internally raised invalid exception "
+                     ++ T.unpack clsName ++ "(\"" ++ T.unpack description ++ "\")")
 

--- a/src/Hython/Interpreter.hs
+++ b/src/Hython/Interpreter.hs
@@ -118,7 +118,7 @@ defaultExceptionHandler ex = do
                 putStr . T.unpack . className . objectClass $ info
                 putStr ": "
                 putStrLn msg
-        _ -> liftIO $ putStrLn "o_O: raised a non-object exception"
+        _ -> liftIO $ putStrLn "SystemError: uncaught non-object exception"
 
     liftIO exitFailure
 

--- a/src/Hython/Statement.hs
+++ b/src/Hython/Statement.hs
@@ -19,7 +19,7 @@ import Language.Python
 import Hython.Builtins (isInstance, len, setAttr)
 import Hython.ControlFlow
 import Hython.Environment
-import qualified Hython.ExceptionHandling as EH
+import Hython.ExceptionHandling (raiseExternal)
 import Hython.Expression (evalExpr, evalParam)
 import qualified Hython.Module as Module
 import Hython.Ref
@@ -173,7 +173,7 @@ eval (Nonlocal names) = mapM_ bindNonlocal names
 
 eval (Pass) = return ()
 
-eval (Raise expr _from) = EH.raise =<< evalExpr expr
+eval (Raise expr _from) = raiseExternal =<< evalExpr expr
 
 eval (Reraise) = do
     mexception  <- getCurrentException

--- a/test/control/exception.py
+++ b/test/control/exception.py
@@ -263,8 +263,7 @@ except BaseException:
 try:
     raise Exception("test")
 except Exception as e:
-    if e != None:           # Test that e exists since we don't implement __str__
-        print("Exists!")
+    print(e)
 
 # Test that the correct handler is located, even if it exists in outer scopes
 def test_caught_by_outside_handlers():

--- a/test/control/exception.py
+++ b/test/control/exception.py
@@ -340,3 +340,30 @@ try:
     print(test_return_in_while())
 finally:
     print("OK!")
+
+# Test that only objects can be raised
+try:
+    raise 3
+except TypeError as e:
+    print("TypeError1")
+
+# Test that only classes derived from BaseException can be raised
+class T:
+    def __str__(self):
+        return "T"
+
+try:
+    raise T("e")
+except TypeError:
+    print("TypeError2")
+
+# Test that only classes derived from BaseException can be caught
+try:
+    try:
+        raise Exception("test")
+    except T:
+        pass
+except TypeError:
+    print("TypeError3")
+except:
+    print("caught something else")


### PR DESCRIPTION
Hi Matt,

I made some changes regarding exception handling. Previously you could raise anything at all and catch "real objects" (Object ObjectInfo) of any class. You can see that in the tests I added.
The behavior now matches the Python interpreter more closely and only allows raising and catching exceptions deriving from BaseException.

&nbsp;

When digging around in the code I found some more things that seem to be not handled completely right. I think we agree that achieving perfectly identical behavior would make the code more complex and is not the goal of this project, but I will mention them briefly (for reference):
- Evaluation (and check of correctness) of except clauses should happen only when an exception
  was raised and could be caught by them.
  E.g. this works fine in Python 3.5 (but not when changing the order of the two except clauses):

  ```python
  try:
        raise Exception()
  except Exception:
        print("caught")
  except 3:
       pass
  ```

  This means ```ExceptionHandler``` should contain an ```Expression``` instead of a ```ClassInfo```.
  Also, it is legal for this expression to be a tuple of multiple valid exception classes
  (e.g. ```except (SystemError, TypeError):```).
- Parsing: ```xor_expr: and_expr ('^' and_expr)``` should be ```xor_expr: (xor_expr '^') and_expr``` (the same for and, or etc.). Currently ```1 ^ 2 ^ 3``` is a parsing error.
- Parsing: In the language reference, there exists a separate ```target``` type, mainly for assignment.
  you can not assign to an ```expression_list```, only to a ```target_list```, which makes code like
  ```1 + 2 = "test"``` a parsing error instead of having to handle it later.
- Optional function parameters should come in the end. Code like ```def f(a = 1, b): print(a, b)``` should not be allowed. Calling ```f(3)``` causes ```Prelude.!!: index too large```.


I also found a nice way to create an endless loop in the interpeter: Redefining exception types and causing an internal exception e.g.:
```python
TypeError = 3
"".a
```
This is because internal exceptions are raised by the name of the exception. ```raiseInternal``` then looks up the corresponding class to create an exception object. If that fails, it raises an exception (and now the same thing happens again and again). :D
Redefining existing classes is nothing you would normally do, though, so I see no need to fix it.

Matthias