### PR TITLE
Fix merge error, clean up Interpreter monad

### DIFF
--- a/src/Hython/Interpreter.hs
+++ b/src/Hython/Interpreter.hs
@@ -17,7 +17,6 @@ import qualified Data.Text as T
 import System.Directory (canonicalizePath, doesFileExist, getDirectoryContents)
 import System.Environment.Executable (splitExecutablePath)
 import System.FilePath
-import System.Exit (exitFailure)
 
 import Language.Python.Parser (parse)
 
@@ -116,13 +115,9 @@ defaultExceptionHandler ex = do
         Object info -> do
             let cls = T.unpack . className . objectClass $ info
             msg <- toStr =<< invoke ex "__str__" []
-            liftIO $ do
-                putStr . T.unpack . className . objectClass $ info
-                putStr ": "
-                putStrLn msg
-        _ -> liftIO $ putStrLn "SystemError: uncaught non-object exception"
-
-    liftIO exitFailure
+            return $ cls ++ ": " ++ msg
+        _ -> return "o_O: raised a non-object exception"
+    Interpreter $ modify (\s -> s { stateErrorMsg = Just message })
 
 defaultReturnHandler :: Object -> Interpreter ()
 defaultReturnHandler _ = raise "SyntaxError" "'return' outside function"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -42,5 +42,5 @@ runScript path = do
   where
     errorHandler :: String -> IOError -> IO Text
     errorHandler _ err = do
-        putStrLn $ "Unable to open '" ++ path ++ "': " ++ ioeGetErrorString err
+        hPutStrLn stderr $ "Unable to open '" ++ path ++ "': " ++ ioeGetErrorString err
         exitFailure

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -13,7 +13,7 @@ import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error
 
-import Hython.Interpreter (defaultInterpreterState, runInterpreter)
+import Hython.Interpreter (defaultInterpreterState, interpret)
 import REPL (runREPL)
 
 main :: IO ()
@@ -32,7 +32,7 @@ runScript path = do
     code <- readFile path `catch` errorHandler path
     state <- defaultInterpreterState path
 
-    (result, _) <- runInterpreter state code
+    (result, _) <- interpret state code
     case result of
         Left msg    -> do
             hPutStrLn stderr msg

--- a/src/REPL.hs
+++ b/src/REPL.hs
@@ -5,7 +5,7 @@ import Data.Text (pack)
 
 import System.Console.Haskeline
 
-import Hython.Interpreter (defaultInterpreterState, runInterpreter)
+import Hython.Interpreter (defaultInterpreterState, interpret)
 
 runREPL :: IO ()
 runREPL = do
@@ -18,7 +18,7 @@ runREPL = do
             Nothing         -> return ()
             Just "quit()"   -> return ()
             Just line -> do
-                (result, newState) <- liftIO $ runInterpreter state (pack line)
+                (result, newState) <- liftIO $ interpret state (pack line)
                 case result of
                     Left s      -> outputStrLn s
                     Right strs  -> mapM_ outputStrLn strs


### PR DESCRIPTION
I added ExceptT to the transformer stack, which allowed me to get rid of the errorMsg in InterpreterState (which was a bit hacky).
Also, loading the builtins now happens in defaultInterpreterState, so I could remove stateNew from InterpreterState as well.

I changed ```ContT Object ...``` to ```ContT (Either String ()) ...``` to return an Either from the continuation and wondered why it was Object before. Was there a specific reason?