### PR TITLE
Assigning to list elements (setitem)

### DIFF
--- a/lib/builtins/builtins.py
+++ b/lib/builtins/builtins.py
@@ -138,8 +138,11 @@ class dict(object):
 
 
 class list(object):
-    def __init__(self):
+    def __init__(self, iterable=None):
         self._list = __hython_primitive__("list-new")
+        if iterable != None:
+            for e in iterable:
+                self.append(e)
 
     def __add__(self, r):
         result = list()

--- a/lib/builtins/builtins.py
+++ b/lib/builtins/builtins.py
@@ -167,10 +167,7 @@ class list(object):
 
     def __getitem__(self, index):
         if index < 0:
-            index = self.__len__() - index
-        if index >= self.__len__():
-            raise IndexError("list index out of range")
-
+            index += len(self)
         return __hython_primitive__("list-get", self._list, index)
 
     def __len__(self):
@@ -185,6 +182,11 @@ class list(object):
 
     def __rawitems__(self):
         return self._list
+
+    def __setitem__(self, index, value):
+        if index < 0:
+            index += len(self)
+        return __hython_primitive__("list-set", self._list, index, value)
 
     def __str__(self):
         s = "["

--- a/src/Hython/BuiltinTypes/List.hs
+++ b/src/Hython/BuiltinTypes/List.hs
@@ -36,9 +36,9 @@ listGet ref (Int i) = do
         Nothing     -> do
             raise "IndexError" "list index out of range"
             return None
-
+listGet ref (Bool b) = listGet ref (Int . toInteger . fromEnum $ b)
 listGet _ _ = do
-    raise "TypeError" "list indicies must be integers"
+    raise "TypeError" "list indices must be integers"
     return None
 
 listLength :: MonadInterpreter m => ListRef -> m Object

--- a/src/Hython/Primitive.hs
+++ b/src/Hython/Primitive.hs
@@ -22,9 +22,10 @@ callPrimitive prim args = case (prim, args) of
     ("list-clear", [List ref])          -> listClear ref
     ("list-concat", [List l, List r])   -> listConcat l r
     ("list-contains", [List l, obj])    -> listContains l obj
-    ("list-get", [List l, obj])         -> listGet l obj
+    ("list-get", [List l, idx])         -> listGet l idx
     ("list-length", [List l])           -> listLength l
     ("list-new", [])                    -> listNew
+    ("list-set", [List l, idx, val])    -> listSet l idx val
     ("print", _)                        -> do
         strs <- mapM toStr args
         liftIO . putStrLn . unwords $ strs

--- a/src/Hython/Statement.hs
+++ b/src/Hython/Statement.hs
@@ -69,9 +69,9 @@ eval (Assignment (TupleDef targetExprs) expr) = do
     targetLen = length targetExprs
 
 eval (Assignment (Subscript targetExpr keyExpr) expr) = do
+    value   <- evalExpr expr
     target  <- evalExpr targetExpr
     key     <- evalExpr keyExpr
-    value   <- evalExpr expr
 
     void $ invoke target "__setitem__" [key, value]
 

--- a/test/builtins/list.py
+++ b/test/builtins/list.py
@@ -5,9 +5,30 @@ print([1,2,])
 print([1,2,3][0])
 print([1,2,3][1])
 
+l = [5,6,7,8]
+
+# negative indexing
+print(l[-1])
+print(l[-3])
+
 # indexing by booleans
 print([1,2,3][False])
 print([1,2,3][True])
+
+# index out of bounds
+try:
+    print(l[4])
+except IndexError:
+    print("IndexError")
+try:
+    print(l[-5])
+except IndexError:
+    print("IndexError")
+
+# print lists
+print([-5,4,472])
+print([[[]]])
+
 
 l = list()
 print(l.__len__())
@@ -30,3 +51,15 @@ l = [1,5,10]
 print(1 in l)
 print(8 in l)
 print(8 not in l)
+
+# assignment
+l[0] = 99
+l[-1] = -1
+l[True] = list()
+print(l)
+
+# order of evaluation
+def p(x):
+    print(x)
+    return x
+p(l)[p(0)] = p(2)

--- a/test/builtins/list.py
+++ b/test/builtins/list.py
@@ -5,6 +5,10 @@ print([1,2,])
 print([1,2,3][0])
 print([1,2,3][1])
 
+# indexing by booleans
+print([1,2,3][False])
+print([1,2,3][True])
+
 l = list()
 print(l.__len__())
 

--- a/test/builtins/list.py
+++ b/test/builtins/list.py
@@ -52,6 +52,17 @@ print(1 in l)
 print(8 in l)
 print(8 not in l)
 
+# construct list from iterable
+l1 = list([3,4,5])
+print(len(l1))
+print(l1)
+l2 = list("test")
+print(len(l2))
+
+# iterate over list
+for e in l2:
+    print(e)
+
 # assignment
 l[0] = 99
 l[-1] = -1


### PR DESCRIPTION
Setting an element of a list was not possible (e.g. ```l[1] = 0```). This is now fixed.
Also, lists can be created from iterables.